### PR TITLE
LIME-165: Added additional character to max length check to facilitate spaces in post codes

### DIFF
--- a/src/app/drivingLicence/fields.js
+++ b/src/app/drivingLicence/fields.js
@@ -119,7 +119,7 @@ module.exports = {
     journeyKey: "postcode",
     validate: [
       "required",
-      { type: "maxlength", arguments: [7] },
+      { type: "maxlength", arguments: [8] },
       { type: "minlength", arguments: [5] },
       { type: "regexPostcode", fn: (value) => value.match(/([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})/) }
     ],


### PR DESCRIPTION
## Proposed changes

### What changed

Upped postcode length to 8 characters

### Why did it change

To allow users with spaces in there postcodes

