### PR TITLE
LIME-149 - Updating common-express version reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "cfenv": "1.2.4",
     "connect-dynamodb": "^2.0.5",
     "copyfiles": "2.4.1",
-    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.30",
+    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.37",
     "dotenv": "^16.0.1",
     "express": "4.18.1",
     "express-async-errors": "^3.1.1",


### PR DESCRIPTION
### What changed

Updated release version reference for common-express

### Why did it change

To reference latest express version that includes fixes for accessibility 