### PR TITLE
LIME-401 - Licence-Issuer screen updated with details dropdown

### DIFF
--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -31,7 +31,7 @@ govuk:
         paragraph2: " at any time."
       buttonAcceptText: Accept analytics cookies
       buttonRejectText: Reject analytics cookies
-      linkViewCookies: View cookies
+      linkViewCookiesText: View cookies
       cookieBannerHideLink: Hide this message
   footerNavItems:
     meta:
@@ -73,3 +73,7 @@ prove-another-way:
 licence-issuer:
   title: Who was your UK driving licence issued by?
   content: You can find this in section 4c of your driving licence. It will either say DVLA (Driving and vehicle Licensing Agency) or DVA (Driver and Vehicle Agency).
+  details:
+    summary: Why we need to know this
+    text:
+      - We need to make sure we check your driving licence details with the right organisation. DVLA issues driving licences in England, Scotland and Wales. DVA issues driving licences in Northern Ireland.

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -9,6 +9,10 @@ licence-issuer:
   title: Who was your UK driving licence issued by?
   content:
     - You can find this in section 4c of your driving licence. It will either say DVLA (Driving and vehicle Licensing Agency) or DVA (Driver and Vehicle Agency).
+  details:
+    summary: Why we need to know this
+    text:
+      - We need to make sure we check your driving licence details with the right organisation. DVLA issues driving licences in England, Scotland and Wales. DVA issues driving licences in Northern Ireland.
 
 details:
   title: Enter your details exactly as they appear on your UK driving licence

--- a/src/views/drivingLicence/licence-issuer.html
+++ b/src/views/drivingLicence/licence-issuer.html
@@ -4,6 +4,8 @@
 {% from "hmpo-text/macro.njk" import hmpoText %}
 {% from "hmpo-form/macro.njk" import hmpoForm %}
 {% from "hmpo-radios/macro.njk" import hmpoRadios %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "hmpo-details/macro.njk" import hmpoDetails %}
 
 {% call hmpoForm(ctx, {attributes: {onsubmit: 'window.disableFormSubmit()'} }) %}
 
@@ -11,11 +13,17 @@
 id: "licenceIssuerRadio"
 }) }}
 
-
 {% endcall %}
 
 {% block submitButton %}
     {{ hmpoSubmit(ctx, {id: 'submitButton'}) }}
+{% endblock %}
+
+{% block innerContent %}
+    {{ govukDetails({
+        summaryText: translate("pages.licence-issuer.details.summary"),
+        text: translate("pages.licence-issuer.details.text")
+    }) }}
 {% endblock %}
 
 {% set footerNavItems = translate("govuk.footerNavItems") %}


### PR DESCRIPTION
### What changed

Updated licence-issuer screen to include additional guidance on the differentiation between DVA/DVLA for driving licence details entry

### Why did it change

To reduce confusion surrounding driving licence issuers
