### PR TITLE
LIME-401 - Moving Details dropdown to below submit

### DIFF
--- a/src/views/drivingLicence/licence-issuer.html
+++ b/src/views/drivingLicence/licence-issuer.html
@@ -15,16 +15,16 @@ id: "licenceIssuerRadio"
 
 {% endcall %}
 
+
 {% block submitButton %}
     {{ hmpoSubmit(ctx, {id: 'submitButton'}) }}
-{% endblock %}
 
-{% block innerContent %}
     {{ govukDetails({
         summaryText: translate("pages.licence-issuer.details.summary"),
         text: translate("pages.licence-issuer.details.text")
     }) }}
 {% endblock %}
+
 
 {% set footerNavItems = translate("govuk.footerNavItems") %}
 


### PR DESCRIPTION
### What changed

Moved details dropdown below submit button

### Why did it change

To Make page in line with content designers specification