### PR TITLE
SPIKE: Add character count for driving licence to details page

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -12,6 +12,9 @@ $govuk-assets-path: "/public/";
   background-color: $govuk-error-colour;
 }
 
+// remove the resize option on the driving licence number character count
+textarea[name="drivingLicenceNumber"] {resize: none;}
+
 //// Task list pattern
 //
 //.app-task-list {

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -1,6 +1,7 @@
 drivingLicenceNumber:
   label: Licence number
   hint: "This is the long number in section 5 on your licence for example HARRI559146MJ931"
+  maxlength: false
   validation:
     default: "Enter the number exactly as it appears on your driving licence"
     exactlength: "Your licence number should be 16 characters long"
@@ -8,6 +9,7 @@ drivingLicenceNumber:
     limit: "Driving licence numbers do not start with 16 – Enter the number exactly as it appears on your driving licence"
     dvlaChecker: "Enter the number exactly as it appears on your driving licence"
     regexSpecialCharacters: "Your licence number should not include any symbols or spaces"
+
 dvaLicenceNumber:
   label: Licence number
   hint: "This is the long number in section 5 on your licence"
@@ -16,6 +18,7 @@ dvaLicenceNumber:
     exactlength: "Your licence number should be 8 characters long"
     regexSpecialCharacters: "Your licence number should not include any symbols or spaces"
     numeric: "Enter the number exactly as it appears on your driving licence"
+
 issueNumber:
   label: Issue number
   hint: "This is the 2 digit number after the space in section 5 of your licence"

--- a/src/views/drivingLicence/details.html
+++ b/src/views/drivingLicence/details.html
@@ -8,6 +8,7 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% from "hmpo-text/macro.njk" import hmpoText %}
+{% from "./hmpoCountText.njk" import hmpoCountText %}
 {% from "hmpo-form/macro.njk" import hmpoForm %}
 {% from "hmpo-date/macro.njk" import hmpoDate %}
 
@@ -169,27 +170,30 @@ html: translate("drivingLicence.drivingLicenceTryAnotherWay")
     }) }}
 
     {% if (values.licenceIssuer == "DVLA") %}
-    {{ hmpoText(ctx, {
+
+        {{ hmpoCountText(ctx, {
         id: "drivingLicenceNumber",
         label: {
             classes: "govuk-label"
         }
-    }) }}
+        }) }}
 
         {{ hmpoText(ctx, {
         id: "issueNumber",
+        classes: "govuk-input--width-3",
         label: {
         classes: "govuk-label"
         }
         }) }}
 
     {% else %}
-    {{ hmpoText(ctx, {
+
+        {{ hmpoCountText(ctx, {
         id: "dvaLicenceNumber",
         label: {
         classes: "govuk-label"
         }
-    }) }}
+        }) }}
 
     {% endif %}
 

--- a/src/views/drivingLicence/hmpoCountText.njk
+++ b/src/views/drivingLicence/hmpoCountText.njk
@@ -1,0 +1,62 @@
+
+{% macro hmpoCountText(ctx, params, base) %}
+
+    {%- set params = hmpoGetParams(ctx, params, base) %}
+
+    {%- set pageHeading = {
+        isPageHeading: true,
+        classes: "govuk-label--l"
+    } if params.isPageHeading %}
+
+    {%- set args = {
+        id: params.id,
+        name: params.id,
+        label: merge(
+            pageHeading,
+            { attributes: { id: params.id + "-label" } },
+            hmpoGetOptions(ctx, params, "label")
+        ),
+        hint: hmpoGetOptions(ctx, params, "hint", true),
+        value: hmpoGetValue(ctx, params),
+        errorMessage: hmpoGetError(ctx, params),
+        type: params.type,
+        inputmode: params.inputmode,
+        classes: "" + (params.classes if params.classes else "govuk-!-width-one-half") + (" js-nopaste" if params.noPaste),
+        formGroup: params.formGroup,
+        autocomplete: params.autocomplete,
+        rows: params.rows,
+        attributes: hmpoGetAttributes(ctx, params, {
+            "aria-required": hmpoGetValidatorAttribute(ctx, params, "required", null, false),
+            "min": hmpoGetValidatorAttribute(ctx, params, "min", 0),
+            "max": hmpoGetValidatorAttribute(ctx, params, "max", 0),
+            "maxlength": hmpoGetValidatorAttribute(ctx, params, "maxlength", 0) or hmpoGetValidatorAttribute(ctx, params, "exactlength", 0)
+        } | filter(null))
+    } %}
+
+    {%- if params.type == "textarea" %}
+        {%- from "govuk/components/textarea/macro.njk" import govukTextarea %}
+        {{- govukTextarea(args) }}
+    {%- else %}
+    {%- from "govuk/components/character-count/macro.njk" import govukCharacterCount %}
+     {%- from "govuk/components/input/macro.njk" import govukInput %}
+
+
+       {# {{- govukInput(args) }}  #}
+       {{ govukCharacterCount({
+         name: args.name,
+         id: args.id,
+         maxlength: args.attributes.maxlength,
+         rows:1,
+         value: args.value,
+         label: {
+           id:args.label.id,
+           text: args.label.html,
+           classes: args.label.classes,
+           isPageHeading: false
+         },
+         hint: {
+           text: args.hint.html
+         }
+       }) }}
+    {%- endif %}
+{% endmacro %}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

This is a working proof of concept for integrating the GDS Design System character count into the driving licence CRI form.

### What changed

<!-- Describe the changes in detail - the "what"-->
The [character count component](https://design-system.service.gov.uk/components/character-count/) gives users a real-time countdown of the number of characters they have left to enter information. To make this work in the HMPO app context, these files were changed:
* `src/assets/scss/application.scss` to remove the resize user interface for the `<textarea>` used by the character count component
* `src/locales/en/fields.yml` removes the `maxlength` from the field, as setting maxlength does not report the status of user input to the user for screenreaders
* `src/views/drivingLicence/details.html` uses the custom `hmpoCountText` nunjucks macro which instantiates the character count component for DVA and DVLA driving licence
* `src/views/drivingLicence/hmpoCountText.njk` is a modification of the `hmpoCount` nunjucks macro which displays the form field using the passed-in variables, with the addition of the character count macro.

Currently the new form **has not been tested** to ensure that the information users supply is being sent to the backend correctly, but the validation does seem to be correct when tested with details from a real driving licence.