### PR TITLE
LIME-570 Simplify data handling by mapping document issue dates (issueDate and dateOfIssue) to issueDate.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@
 <!-- List any related ADRs or RFCs -->
 <!-- Delete/copy as appropriate -->
 
-- [PYIC-XXXX](https://govukverify.atlassian.net/browse/PYIC-XXX)
+- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXX)
 
 ## Checklists
 

--- a/src/app/drivingLicence/controllers/validate.js
+++ b/src/app/drivingLicence/controllers/validate.js
@@ -27,8 +27,7 @@ class ValidateController extends BaseController {
         req.sessionModel.get("dvaDateOfBirth") ||
         req.sessionModel.get("dateOfBirth"),
       expiryDate: req.sessionModel.get("expiryDate"),
-      issueDate: req.sessionModel.get("issueDate") || null,
-      dateOfIssue: req.sessionModel.get("dateOfIssue"),
+      issueDate: req.sessionModel.get("issueDate") || req.sessionModel.get("dateOfIssue"),
       licenceIssuer: req.sessionModel.get("licenceIssuer"),
     };
 


### PR DESCRIPTION
## Proposed changes

### What changed

Map issueDate and dateOfIssue to one field issueDate in data submission to backend api.

### Why did it change

Differentiation between dateOfIssue and issueDate is only needed on the entry form (for the user) and on data sent to the third-party (send fieldname can be determined by issuer at request creation). For the remainder of the CRI (VC/audit events) they are the treated as just issueDate. By merging the fields early this avoids the needing to map both fields thought-out and avoids errors appearing by incorrectly mapping to the other field.

### Issue tracking

- [LIME-570](https://govukverify.atlassian.net/browse/LIME-570)