### PR TITLE
LIME-650 - Updated service name to say Prove your identity

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -6,7 +6,7 @@ govuk:
   phaseBanner:
     tag: beta
     content: Mae hwn yn wasanaeth newydd – <a href="https://signin.account.gov.uk/contact-us" class="govuk-link" rel="noopener" target="_blank">bydd eich adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
-  serviceName: " "
+  serviceName: Profi pwy ydych chi
   backLink: Back
   errorSummaryTitle: Mae problem
   error: Gwall

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -6,7 +6,7 @@ govuk:
   phaseBanner:
     tag: beta
     content: This is a new service – your <a href="https://signin.account.gov.uk/contact-us" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
-  serviceName: " "
+  serviceName: Prove your identity
   backLink: Back
   errorSummaryTitle: There is a problem
   error: Error


### PR DESCRIPTION
### What changed

Updated the service name to say Prove your identity and Profi pwy ydych chi for English and Welsh

### Why did it change

To include the service name in the page titles
