### PR TITLE
LIME-655 - Corrected neu spelling in DL frontend

### DIFF
--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -153,7 +153,7 @@ licenceIssuer:
       label: DVA
       value: DVA
     or:
-      label: nue
+      label: neu
       value: or
     noLicence:
       label: Nid oes gennyf drwydded yrru y DU


### PR DESCRIPTION
### What changed

Corrected neu spelling in DL frontend

### Why did it change

To reflect the correct Welsh translation
