### PR TITLE
LIME-661 Allow enter button form submission when submit button is focused in keyboard navigation

### DIFF
--- a/src/views/drivingLicence/details.html
+++ b/src/views/drivingLicence/details.html
@@ -243,10 +243,14 @@ classes: "govuk-input"
 
     <script nonce="{{ cspNonce }}">
 
-<!--    Disable enter button from submitting the form-->
+<!--    Disable enter button from submitting the form but allow if form submit button is focused-->
     var form = document.getElementsByTagName('form')[0];
     form.addEventListener("keydown", function (event) {
-        if (event.code === 'Enter'){
+
+        var submitButton = document.getElementById('continue')
+        var submitButtonIsNotFocused = document.activeElement !== submitButton;
+
+        if ((event.code === 'Enter') && submitButtonIsNotFocused){
             event.preventDefault();
         }
     });


### PR DESCRIPTION
## Proposed changes

### What changed

Previous fix to prevent accidental form submission via enter button presses during form input is overly board - preventing all enter button based form submission

### Why did it change

When using keyboard navigation it should be valid to press enter when the submit button is focused

### Issue tracking

- [LIME-661](https://govukverify.atlassian.net/browse/LIME-661)

[LIME-661]: https://govukverify.atlassian.net/browse/LIME-661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ