### PR TITLE
LIME-713 - Hotfix to address JS caching the compilation date  as `TODAY`.

### DIFF
--- a/src/app/drivingLicence/fields.js
+++ b/src/app/drivingLicence/fields.js
@@ -49,7 +49,7 @@ module.exports = {
     validate: [
       "required",
       "date",
-      { type: "before", arguments: [new Date().toISOString().split("T")[0]] },
+      { type: "before", arguments: [] },
       {
         type: "dvlaChecker",
         ...dvlaValidatorObj,
@@ -60,11 +60,7 @@ module.exports = {
   dvaDateOfBirth: {
     type: "date",
     journeyKey: "dvaDateOfBirth",
-    validate: [
-      "required",
-      "date",
-      { type: "before", arguments: [new Date().toISOString().split("T")[0]] },
-    ],
+    validate: ["required", "date", { type: "before", arguments: [] }],
     dependent: { field: "issuerDependent", value: "DVA" },
   },
   issueDate: {
@@ -75,15 +71,7 @@ module.exports = {
       "date",
       {
         type: "before",
-        arguments: [
-          new Date(
-            new Date().getFullYear(),
-            new Date().getMonth(),
-            new Date().getDate()
-          )
-            .toISOString()
-            .split("T")[0],
-        ],
+        arguments: [],
       },
     ],
     dependent: { field: "issuerDependent", value: "DVLA" },
@@ -96,15 +84,7 @@ module.exports = {
       "date",
       {
         type: "before",
-        arguments: [
-          new Date(
-            new Date().getFullYear(),
-            new Date().getMonth(),
-            new Date().getDate()
-          )
-            .toISOString()
-            .split("T")[0],
-        ],
+        arguments: [],
       },
     ],
     dependent: { field: "issuerDependent", value: "DVA" },
@@ -122,15 +102,7 @@ module.exports = {
       "date",
       {
         type: "after",
-        arguments: [
-          new Date(
-            new Date().getFullYear(),
-            new Date().getMonth(),
-            new Date().getDate()
-          )
-            .toISOString()
-            .split("T")[0],
-        ],
+        arguments: [],
       },
     ],
   },


### PR DESCRIPTION
## Proposed changes

### What changed

- During compilation of the JS, some functions are cached for later use. One of these functions attempts to get today's date. Due to this, `TODAY` will always been  read as the date  of compilation and not the user's date.
- This change removes the function call, relaying that responsibility to the `before` / `after` functions where checks are done. These functions are unaffected by the caching.

### Issue tracking

- [LIME-713](https://govukverify.atlassian.net/jira/software/c/projects/LIME/issues/LIME-713)

## Checklists

### Other considerations

- Due to timezone conversion to UTC, `TODAY` is still one day out during BST. This should be taken into consideration during further testing.


[LIME-713]: https://govukverify.atlassian.net/browse/LIME-713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<img width="581" alt="image" src="https://github.com/alphagov/di-ipv-cri-dl-front/assets/107932230/68c74d70-f005-4ea5-81d9-a8279066c118">
