### PR TITLE
LIME-1480 hmpo-components dependency updated and amendments made to a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "express-session": "^1.17.3",
     "govuk-frontend": "4.9.0",
     "hmpo-app": "2.4.0",
-    "hmpo-components": "6.4.0",
+    "hmpo-components": "7.1.0",
     "hmpo-config": "3.0.0",
     "hmpo-form-wizard": "12.0.6",
     "hmpo-i18n": "5.0.2",

--- a/src/app/drivingLicence/fields.js
+++ b/src/app/drivingLicence/fields.js
@@ -165,7 +165,8 @@ module.exports = {
     type: "hidden",
     label: "",
     legend: "",
-    hint: ""
+    hint: "",
+    prefix: ""
   },
   expiryDate: {
     type: "date",

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -1,6 +1,7 @@
 drivingLicenceNumber:
   label: Rhif trwydded
   hint: "Dyma'r rhif hir yn adran 5 ar eich trwydded er enghraifft HARRI559146MJ931"
+  prefix: ""
   validation:
     default: "Rhowch y rhif yn union fel mae’n ymddangos ar eich trwydded yrru"
     licenceLength: "Dylai rhif eich trwydded fod yn 16 nod o hyd"
@@ -11,6 +12,7 @@ drivingLicenceNumber:
 dvaLicenceNumber:
   label: Rhif trwydded
   hint: "Dyma'r rhif hir yn adran 5 ar eich trwydded"
+  prefix: ""
   validation:
     default: "Rhowch y rhif yn union fel mae’n ymddangos ar eich trwydded yrru"
     licenceLength: "Dylai rhif eich trwydded fod yn 8 nod o hyd"
@@ -19,6 +21,7 @@ dvaLicenceNumber:
 issueNumber:
   label: Rhif cyhoeddi
   hint: "Dyma'r rhif 2 ddigid ar ôl y gofod yn adran 5 o'ch trwydded"
+  prefix: ""
   validation:
     default: "Rhowch y rhif cyhoeddi fel y mae'n ymddangos ar eich trwydded yrru"
     exactlength: "Dylai eich rhif cyhoeddi fod yn 2 rif o hyd"
@@ -28,6 +31,7 @@ issueNumber:
 surname:
   label: Enw olaf
   hint: ""
+  prefix: ""
   validation:
     default: "Rhowch eich enw olaf fel y mae'n ymddangos ar eich trwydded yrru"
     maxlength: "Rhowch eich enw olaf fel y mae'n ymddangos ar eich trwydded yrru"
@@ -37,6 +41,7 @@ surname:
 firstName:
   label: Enw cyntaf
   hint: "Mae hwn yn adran 2 o'ch trwydded. Nid oes angen i chi gynnwys eich teitl."
+  prefix: ""
   validation:
     default: "Rhowch eich enw cyntaf fel y mae'n ymddangos ar eich trwydded yrru"
     maxlength: "Rhowch eich enw cyntaf fel y mae'n ymddangos ar eich trwydded yrru"
@@ -47,6 +52,7 @@ firstName:
 middleNames:
   label: Enwau canol
   hint: "Gadewch hyn yn wag os nad oes gennych unrhyw enwau canol"
+  prefix: ""
   validation:
     maxlength: "Rhowch unrhyw enwau canol fel y maent yn ymddangos ar eich trwydded yrru"
     regexMiddleNames: "Rhowch unrhyw enwau canol fel y maent yn ymddangos ar eich trwydded yrru"
@@ -101,6 +107,7 @@ expiryDate:
 postcode:
   label: Cod post
   hint: "Rhowch y cod post yn y cyfeiriad yn adran 8 o'ch trwydded"
+  prefix: ""
   validation:
     default: "Rhowch eich cod post"
     minlength: "Dylai eich rhowch eich cod post fod rhwng 5 a 7 nod"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -1,6 +1,7 @@
 drivingLicenceNumber:
   label: Licence number
   hint: "This is the long number in section 5 on your licence for example HARRI559146MJ931"
+  prefix: ""
   validation:
     default: "Enter the number exactly as it appears on your driving licence"
     licenceLength: "Your licence number should be 16 characters long"
@@ -11,6 +12,7 @@ drivingLicenceNumber:
 dvaLicenceNumber:
   label: Licence number
   hint: "This is the long number in section 5 on your licence"
+  prefix: ""
   validation:
     default: "Enter the number exactly as it appears on your driving licence"
     licenceLength: "Your licence number should be 8 characters long"
@@ -19,6 +21,7 @@ dvaLicenceNumber:
 issueNumber:
   label: Issue number
   hint: "This is the 2 digit number after the space in section 5 of your licence"
+  prefix: ""
   validation:
     default: "Enter the issue number as it appears on your driving licence"
     exactlength: "Your issue number should be 2 numbers long"
@@ -28,6 +31,7 @@ issueNumber:
 surname:
   label: Last name
   hint: ""
+  prefix: ""
   validation:
     default: "Enter your last name as it appears on your driving licence"
     maxlength: "Enter your last name as it appears on your driving licence"
@@ -37,6 +41,7 @@ surname:
 firstName:
   label: First name
   hint: "This is in section 2 of your licence. You do not need to include your title."
+  prefix: ""
   validation:
     default: "Enter your first name as it appears on your driving licence"
     maxlength: "Enter your first name as it appears on your driving licence"
@@ -47,6 +52,7 @@ firstName:
 middleNames:
   label: Middle names
   hint: "Leave this blank if you do not have any middle names"
+  prefix: ""
   validation:
     maxlength: "Enter any middle names as they appear on your driving licence"
     regexMiddleNames: "Enter any middle names as they appear on your driving licence"
@@ -101,6 +107,7 @@ expiryDate:
 postcode:
   label: Postcode
   hint: "Enter the postcode in the address in section 8 of your licence"
+  prefix: ""
   validation:
     default: "Enter your postcode"
     minlength: "Your postcode should be between 5 and 7 characters"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

hmpo-components updated to v7.1.0. This was previously a breaking update due to a .prefix box appearing in every input field in the browser. Workaround implemented to resolve this. 
### Why did it change

To facilitate update to v7.1.0

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1480](https://govukverify.atlassian.net/browse/LIME-1480)

### Other considerations

Same update and workarounds being implemented IN Passport and Fraud FEs.

Evidence on ticket 

[LIME-1480]: https://govukverify.atlassian.net/browse/LIME-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ