### PR TITLE
LIME-1808 - Re enabled tests relating to LIME-666 defect

### DIFF
--- a/test/browser/features/Welsh/DVA/WelshDVA.feature
+++ b/test/browser/features/Welsh/DVA/WelshDVA.feature
@@ -117,8 +117,8 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     Examples:
       | DVADrivingLicenceSubject        | InvalidLicenceNumber |
       | DrivingLicenceSubjectHappyBilly |                      |
-  #      |DrivingLicenceSubjectHappyBilly|55667ABC            | - bug raised under LIME-666
-  #      |DrivingLicenceSubjectHappyBilly|XYZabdAB            | - bug raised under LIME-666
+      | DrivingLicenceSubjectHappyBilly | 55667ABC             |
+      | DrivingLicenceSubjectHappyBilly | XYZabdAB             |
 
   @mock-api:dva-invalidPostcode @language-regression
   Scenario Outline: DVA Driving Licence Postcode less than 5 characters error validation


### PR DESCRIPTION
2 Test Scenario Examples have been commented out in Main in related to LIME-666: DL | Incorrect Validation on DVA Welsh Licence Number (Alpha-Numeric)
In Review
 

Scenario: DVA Driving Licence number with alpha numeric characters or alpha characters or no licence number error validation

Examples: 55667ABC and XYZabdAB

 

As these tests now pass following the resolution of LIME-666: DL | Incorrect Validation on DVA Welsh Licence Number (Alpha-Numeric)
In Review
 the tests need to be uncommented

## Proposed changes

### What changed

Blocked Commented out tests have been uncommented and now pass as expected

### Why did it change

LIME-666 has been resolved and these tests are now unblocked

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1808](https://govukverify.atlassian.net/browse/LIME-1808)
- - [LIME-666](https://govukverify.atlassian.net/browse/LIME-666)

### Other considerations

Test Evidence: 
The following Scenario has been updated so that all examples are now being run:
<img width="1245" height="323" alt="image" src="https://github.com/user-attachments/assets/71e224a8-b581-43b6-b173-3054f2f19a26" />

all tests passing locally:

<img width="434" height="126" alt="image" src="https://github.com/user-attachments/assets/e6a85eff-b72b-4a10-bb05-a19187635e39" />


Language Regression passing locally:
<img width="448" height="129" alt="image" src="https://github.com/user-attachments/assets/d31aeb5e-bbfc-42c6-aa66-176414771e7c" />
All FE regression passing locally:

<img width="438" height="124" alt="image" src="https://github.com/user-attachments/assets/28aef4f4-43c0-4aea-8b11-83fbd4e80e85" />

[LIME-1808]: https://govukverify.atlassian.net/browse/LIME-1808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-666]: https://govukverify.atlassian.net/browse/LIME-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ