### PR TITLE
LIME-1840 - Add event listener to check for console errors

### DIFF
--- a/test/browser/features/English/DLCommon/DLCommon.feature
+++ b/test/browser/features/English/DLCommon/DLCommon.feature
@@ -82,10 +82,10 @@ Feature: Driving licence CRI - Common Tests
         When User clicks the GOV.UK Link
         And I check the GOV.UK page Title GOV.UK
 
-
     @mock-api:driving-licence-PageFooter @validation-regression
     Scenario Outline: Fraud CRI - Footer Links
-        Given they click Footer <link> and assert I have been redirected correctly
+        Given I should be on the Landing Page with Page Title Was your UK photocard driving licence issued by DVLA or DVA?
+        Then they click Footer <link> and assert I have been redirected correctly
         Examples:
             | link           |
             | Accessibility  |

--- a/test/browser/features/English/DVA/DVA.feature
+++ b/test/browser/features/English/DVA/DVA.feature
@@ -389,3 +389,12 @@ Feature: DVA Driving licence CRI Error Validations
     And User clicks on continue
     Then they should see an error page
     Then I run the Axe Accessibility check against the DL Error page
+
+  @mock-api:dva-consoleErrorCheck @console-error-checks
+  Scenario: DVA - User navigates through the DVA Journey - Check for Console Errors
+    Given I see the back button on the DVA details page with text Back
+    And User clicks the back button
+    Then I should be on the Landing Page with Page Title Was your UK photocard driving licence issued by DVLA or DVA?
+    And User starts the Console Listener
+    And I click on DVA radio button and Continue
+    Then There are no console errors on the page

--- a/test/browser/features/English/DVA/DVAAuthSource.feature
+++ b/test/browser/features/English/DVA/DVAAuthSource.feature
@@ -52,3 +52,13 @@ Feature: DVA Driving licence - Auth Source
     Then I click on the Confirm and Continue button
     And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
     And I run the Axe Accessibility check against the Driving Licence Consent page
+
+  @mock-api:dl-dva-auth-success @console-error-checks
+  Scenario: DVA Auth Source - User navigates through the Auth Source Journey - Check for Console Errors
+    When I click on the Yes radio button
+    And User starts the Console Listener
+    Then I click on the Confirm and Continue button
+    Then There are no console errors on the page
+    And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
+    And I click on the DVA consent checkbox
+    When I click on the Continue button

--- a/test/browser/features/English/DVLA/DVLA.feature
+++ b/test/browser/features/English/DVLA/DVLA.feature
@@ -564,3 +564,12 @@ Feature: DVLA Driving licence CRI Error Validations
   @mock-api:dvla-accessibility @accessibility
   Scenario Outline: DVLA - Axe Accessibility Scan - DVLA Details Page
     Given I run the Axe Accessibility check against the DVLA Details page
+
+  @mock-api:dva-consoleErrorCheck @console-error-checks
+  Scenario: DVA - User navigates through the DVA Journey - Check for Console Errors
+    Given I see the back button on the DVLA details page with text Back
+    And User clicks the back button
+    Then I should be on the Landing Page with Page Title Was your UK photocard driving licence issued by DVLA or DVA?
+    And User starts the Console Listener
+    And I click on DVLA radio button and Continue
+    Then There are no console errors on the page

--- a/test/browser/features/English/DVLA/DVLAAuthSource.feature
+++ b/test/browser/features/English/DVLA/DVLAAuthSource.feature
@@ -8,7 +8,6 @@ Feature: DVLA Driving licence - Auth Source
 
     @mock-api:dl-dvla-auth-success @validation-regression
     Scenario: DVLA Auth Source - User navigates through the Auth Source Journey - Check Your Details Page
-
         When I click on the Yes radio button
         Then I click on the Confirm and Continue button
         And I should be on the DVLA consent page We need to check your driving licence details – GOV.UK One Login
@@ -53,3 +52,13 @@ Feature: DVLA Driving licence - Auth Source
         Then I click on the Confirm and Continue button
         And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
         And I run the Axe Accessibility check against the Driving Licence Consent page
+
+    @mock-api:dl-dvla-auth-success @console-error-checks
+    Scenario: DVLA Auth Source - User navigates through the Auth Source Journey - Check for Console Errors
+        When I click on the Yes radio button
+        And User starts the Console Listener
+        Then I click on the Confirm and Continue button
+        Then There are no console errors on the page
+        And I should be on the DVLA consent page We need to check your driving licence details – GOV.UK One Login
+        And I click on the DVLA consent checkbox
+        When I click on the Continue button

--- a/test/browser/pages/CheckYourDetailsPage.js
+++ b/test/browser/pages/CheckYourDetailsPage.js
@@ -135,6 +135,16 @@ exports.CheckYourDetailsPage = class PlaywrightDevPage {
     await this.CTButton.click();
   }
 
+  async setupConsoleListener(page) {
+    const consoleMessages = [];
+    return new Promise((resolve) => {
+      page.on("console", (msg) => {
+        consoleMessages.push({ type: msg.type(), text: msg.text() });
+      });
+      setTimeout(() => resolve(consoleMessages), 500);
+    });
+  }
+
   //  Language
   async assertBetaBanner(betaBannerLabel) {
     await this.page.waitForLoadState("domcontentloaded");

--- a/test/browser/pages/DrivingLicencePage.js
+++ b/test/browser/pages/DrivingLicencePage.js
@@ -313,6 +313,16 @@ exports.DrivingLicencePage = class PlaywrightDevPage {
     await this.Continue.click();
   }
 
+  async setupConsoleListener(page) {
+    const consoleMessages = [];
+    return new Promise((resolve) => {
+      page.on("console", (msg) => {
+        consoleMessages.push({ type: msg.type(), text: msg.text() });
+      });
+      setTimeout(() => resolve(consoleMessages), 500);
+    });
+  }
+
   async userEntersData(issuer, drivingLicenceSubjectScenario) {
     var drivingLicenceSubject = TestDataCreator.getDVLATestUserFromMap(
       issuer,

--- a/test/browser/pages/UniversalSteps.js
+++ b/test/browser/pages/UniversalSteps.js
@@ -5,6 +5,7 @@ exports.UniversalSteps = class PlaywrightDevPage {
     this.page = page;
     this.url = url;
     this.backButton = this.page.locator('xpath=//*[@id="back"]/a');
+    this.consoleMessages = [];
   }
 
   async changeLanguageTo(language) {
@@ -39,5 +40,15 @@ exports.UniversalSteps = class PlaywrightDevPage {
   async clickBackButton() {
     await this.backButton.click();
     await this.page.waitForTimeout(2000); //waitForNavigation and waitForLoadState do not work in this case
+  }
+
+  async setupConsoleListener(page) {
+    const consoleMessages = [];
+    return new Promise((resolve) => {
+      page.on("console", (msg) => {
+        consoleMessages.push({ type: msg.type(), text: msg.text() });
+      });
+      setTimeout(() => resolve(consoleMessages), 500); // Consider a more robust wait strategy
+    });
   }
 };

--- a/test/browser/pages/consent.js
+++ b/test/browser/pages/consent.js
@@ -60,6 +60,16 @@ exports.ConsentPage = class PlaywrightDevPage {
     await this.CTButton.click();
   }
 
+  async setupConsoleListener(page) {
+    const consoleMessages = [];
+    return new Promise((resolve) => {
+      page.on("console", (msg) => {
+        consoleMessages.push({ type: msg.type(), text: msg.text() });
+      });
+      setTimeout(() => resolve(consoleMessages), 500);
+    });
+  }
+
   async assertNoConsentProvidedErrorSummary(errorSummaryText) {
     await this.page.waitForLoadState("domcontentloaded");
     expect(await this.isCurrentPage()).to.be.true;

--- a/test/browser/pages/licence-issuer.js
+++ b/test/browser/pages/licence-issuer.js
@@ -171,6 +171,16 @@ module.exports = class PlaywrightDevPage {
     await this.CTButton.click();
   }
 
+  async setupConsoleListener(page) {
+    const consoleMessages = [];
+    return new Promise((resolve) => {
+      page.on("console", (msg) => {
+        consoleMessages.push({ type: msg.type(), text: msg.text() });
+      });
+      setTimeout(() => resolve(consoleMessages), 500);
+    });
+  }
+
   async clickOnDVARadioButton() {
     expect(await this.page.title()).to.equal(
       "Was your UK photocard driving licence issued by DVLA or DVA? – GOV.UK One Login"

--- a/test/browser/step_definitions/DrivingLicenceStepDefs.js
+++ b/test/browser/step_definitions/DrivingLicenceStepDefs.js
@@ -30,6 +30,7 @@ Then(
 
 Then(/^User clicks on continue$/, { timeout: 2 * 5000 }, async function () {
   const drivingLicencePage = new DrivingLicencePage(this.page);
+  expect(drivingLicencePage.isCurrentPage()).to.be.true;
   await drivingLicencePage.clickOnContinue();
 });
 

--- a/test/browser/step_definitions/UniversalStepDefs.js
+++ b/test/browser/step_definitions/UniversalStepDefs.js
@@ -1,5 +1,6 @@
 const { Given, When, Then } = require("@cucumber/cucumber");
 const { UniversalSteps } = require("../pages/UniversalSteps");
+const { expect: expect } = require("chai");
 
 Then(
   /^I add a cookie to change the language to (.*)$/,
@@ -13,4 +14,18 @@ Then(
 Then(/^User clicks the back button$/, async function () {
   const universalSteps = new UniversalSteps(this.page);
   await universalSteps.clickBackButton();
+});
+
+Then(/^User starts the Console Listener$/, async function () {
+  const universalSteps = new UniversalSteps(this.page);
+  this.consoleMessages = await universalSteps.setupConsoleListener(this.page); // Store in world object
+});
+
+Then(/^There are no console errors on the page$/, async function () {
+  await this.page.waitForTimeout(2000);
+  const errorMessages = this.consoleMessages.filter(
+    (msg) => msg.type === "error"
+  ); // Access from world object
+  expect(errorMessages, `Console errors: ${JSON.stringify(errorMessages)}`).to
+    .be.empty;
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1440,12 +1440,12 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
-"@playwright/test@1.54.1":
-  version "1.54.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.54.1.tgz#a76333e5c2cba5f12f96a6da978bba3ab073c7e6"
-  integrity sha512-FS8hQ12acieG2dYSksmLOF7BNxnVf2afRJdCuM1eMSxj6QTSE6G4InGF7oApGgDb65MX7AwMVlIkpru0yZA4Xw==
+"@playwright/test@1.55.0":
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.55.0.tgz#080fa6d9ee6d749ff523b1c18259572d0268b963"
+  integrity sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==
   dependencies:
-    playwright "1.54.1"
+    playwright "1.55.0"
 
 "@redis/bloom@1.2.0":
   version "1.2.0"
@@ -5953,29 +5953,17 @@ pkg-dir@^4.1.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright-core@1.32.3:
-  version "1.32.3"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.32.3.tgz#e6dc7db0b49e9b6c0b8073c4a2d789a96f519c48"
-  integrity sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==
+playwright-core@1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.55.0.tgz#ec8a9f8ef118afb3e86e0f46f1393e3bea32adf4"
+  integrity sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==
 
-playwright-core@1.54.1:
-  version "1.54.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.54.1.tgz#d32edcce048c9d83ceac31e294a7b60ef586960b"
-  integrity sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA==
-
-playwright@1.32.3:
-  version "1.32.3"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.32.3.tgz#88583167880e42ca04fa8c4cc303680f4ff457d0"
-  integrity sha512-h/ylpgoj6l/EjkfUDyx8cdOlfzC96itPpPe8BXacFkqpw/YsuxkpPyVbzEq4jw+bAJh5FLgh31Ljg2cR6HV3uw==
+playwright@1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.55.0.tgz#7aca7ac3ffd9e083a8ad8b2514d6f9ba401cc78b"
+  integrity sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==
   dependencies:
-    playwright-core "1.32.3"
-
-playwright@1.54.1:
-  version "1.54.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.54.1.tgz#128d66a8d5182b5330e6440be3a72ca313362788"
-  integrity sha512-peWpSwIBmSLi6aW2auvrUtf2DqY16YYcCMO8rTVx486jKmDTJg7UAhyrraP98GB8BoPURZP8+nxO7TSd4cPr5g==
-  dependencies:
-    playwright-core "1.54.1"
+    playwright-core "1.55.0"
   optionalDependencies:
     fsevents "2.3.2"
 
@@ -6856,16 +6844,7 @@ string-argv@~0.3.2:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3, string-width@^5.1.2, string-width@^7.0.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3, string-width@^5.1.2, string-width@^7.0.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6935,14 +6914,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1, strip-ansi@^7.1.0:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1, strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -7508,16 +7480,7 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.3.tgz#e75281fe62e851afb21cdeef8fa85f6a62ec3583"
   integrity sha512-slxCaKbYjEdFT/o2rH9xS1hf4uRDch1w7Uo+apxhZ+sf/1d9e0ZVkn42kPNGP2dgjIx6YFvSevj0zHvbWe2jdw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0, wrap-ansi@^9.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^6.2.0, wrap-ansi@^7.0.0, wrap-ansi@^8.1.0, wrap-ansi@^9.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
New tests added to DVA/ DVLA, DVA Auth Source/ DVLA Auth Source
Tests check that when they progress to either the details page from licence issuer, or the consent page from check-your-details, that no console errors are found during page transition


## Proposed changes

### What changed

Updated Continue step definition with new console event listener

### Why did it change

To capture any console errors generated between page loads

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1840](https://govukverify.atlassian.net/browse/LIME-1840)
- [LIME-1758](https://govukverify.atlassian.net/browse/LIME-1758)

### Other considerations

New Tests for Console Errors passed locally:

<img width="439" height="121" alt="image" src="https://github.com/user-attachments/assets/856d015f-869b-4c79-bd4c-2bf2058138f6" />


[LIME-1840]: https://govukverify.atlassian.net/browse/LIME-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1758]: https://govukverify.atlassian.net/browse/LIME-1758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ