### PR TITLE
fix(1183): removed extra form wrapping that caused double errors to be sent to data, maintained visual styling

### DIFF
--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -5,6 +5,16 @@ $govuk-assets-path: "/public/";
 @import "../../../node_modules/@govuk-one-login/frontend-language-toggle/stylesheet/styles";
 @import "components/button-spinner";
 
+.govuk-form-group--error-visual {
+  border-left: $govuk-border-width-form-group-error solid $govuk-error-colour;
+  padding-left: govuk-spacing(3);
+
+  .govuk-form-group--error {
+    border-left: 0;
+    padding-left: 0;
+  }
+}
+
 // repainting the notification banner red for a warning state on the driving licence CRI [PYIC-1563]
 
 .govuk-notification-banner.driving-licence-message {

--- a/src/views/drivingLicence/details.html
+++ b/src/views/drivingLicence/details.html
@@ -95,10 +95,10 @@ autocomplete: "family-name"
     {%- set middleNameError = hmpoGetError(ctx, {id: 'middleNames'}) %}
 
     {% if firstNameError and middleNameError %}
-        <div class="govuk-form-group govuk-form-group--error">
-        {% else %}
-            <div class="govuk-form-group ">
-            {% endif %}
+        <div class="govuk-form-group govuk-form-group--error-visual">
+    {% else %}
+        <div class="govuk-form-group">
+    {% endif %}
 
             {% call govukFieldset({
         legend: {


### PR DESCRIPTION

Removing nesting in the form error handling that caused two events for first name errors to be sent to google analytics


### Why did it change

Double error reporting was incorrectly flagging

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [DFC-1183](https://govukverify.atlassian.net/browse/DFC-1183)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[DFC-1183]: https://govukverify.atlassian.net/browse/DFC-1183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ