### PR TITLE
LIME-2125 dockerfile updates

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -46,3 +46,4 @@ jobs:
           template-file: deploy/template.yaml
           role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
           ecr-repo-name: ${{ secrets.BUILD_ECR_REPOSITORY }}
+          docker-platform: linux/amd64

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -49,3 +49,4 @@ jobs:
           template-file: deploy/template.yaml
           role-to-assume-arn: ${{ secrets.AWS_DL_DEV_ROLE_ARN }}
           ecr-repo-name: ${{ secrets.DEV_ECR_REPOSITORY }}
+          docker-platform: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.16.0-alpine3.21@sha256:4437d7c27c4b9306c577caa17577dc7b367fc320fb7469dbe2c994e23b11d11c AS builder
+FROM node:22.16.0-alpine3.21@sha256:9f3ae04faa4d2188825803bf890792f33cc39033c9241fc6bb201149470436ca AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN yarn build
 RUN [ "rm", "-rf", "node_modules" ]
 RUN yarn install --production --frozen-lockfile
 
-FROM node:22.16.0-alpine3.21@sha256:4437d7c27c4b9306c577caa17577dc7b367fc320fb7469dbe2c994e23b11d11c AS final
+FROM node:22.16.0-alpine3.21@sha256:9f3ae04faa4d2188825803bf890792f33cc39033c9241fc6bb201149470436ca AS final
 
 RUN ["apk", "--no-cache", "upgrade"]
 
@@ -31,9 +31,9 @@ COPY --from=builder /app/src ./src
 
 # Add in dynatrace layer
 COPY --from=khw46367.live.dynatrace.com/linux/oneagent-codemodules-musl:nodejs / /
-ENV LD_PRELOAD /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+ENV LD_PRELOAD=/opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
 
-ENV PORT 8080
+ENV PORT=8080
 
 HEALTHCHECK --interval=5s --timeout=2s --retries=10 \
   CMD curl -f http://localhost:8080/healthcheck || exit 1
@@ -41,5 +41,3 @@ HEALTHCHECK --interval=5s --timeout=2s --retries=10 \
 EXPOSE $PORT
 
 ENTRYPOINT ["sh", "-c", "export DT_HOST_ID=DL-FRONT-$RANDOM && tini npm start"]
-
-CMD ["yarn", "start"]


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

- swap to index digest for app image, docker will target the correct architecture based on the platform being built from
- remove useless yarn commands from dockerfile
- set required image architecture in GHA (on the off chance ubuntu:latest is changed to ARM in the future)

### Why did it change

- `CMD ["yarn", "start"]` never called so has been removed
- multi-arch sha chosen for compatibility across different build envs (local dev, CI)
- CI actions enforce architecture that the image runs on in ECS

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-2125](https://govukverify.atlassian.net/browse/LIME-2125)

[LIME-2125]: https://govukverify.atlassian.net/browse/LIME-2125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ