### PR TITLE
LIME-2128: Building and pushing pipeline test images on deploy to dev and build

### DIFF
--- a/.github/workflows/post-merge-to-build.yml
+++ b/.github/workflows/post-merge-to-build.yml
@@ -5,9 +5,27 @@ on:
       - main
 
 jobs:
-  dockerBuildAndPush:
+  test-image-build-and-push:
+    name: Build and push test image
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: govuk-one-login/devplatform-upload-action-ecr@f82c8774a6390f200b15112b3cbb9faf3442173c
+        with:
+          role-to-assume-arn: ${{ secrets.GH_ACTIONS_ROLE_ARN }}
+          build-and-push-image-only: true
+          artifact-bucket-name: ''
+          ecr-repo-name: ${{ secrets.BUILD_ECR_REPOSITORY_TEST }}
+          dockerfile: test/Dockerfile
+          push-latest-tag: true
+          container-sign-kms-key-arn: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
+
+  app-image-build-and-push:
     name: Docker build and push
     runs-on: ubuntu-latest
+    needs: test-image-build-and-push
     env:
       AWS_REGION: eu-west-2
     permissions:

--- a/.github/workflows/post-merge-to-dev.yml
+++ b/.github/workflows/post-merge-to-dev.yml
@@ -6,9 +6,27 @@ on:
   workflow_dispatch: # deploy manually
 
 jobs:
-  dockerBuildAndPush:
-    name: Docker build and push
+  test-image-build-and-push:
+    name: Build and push test image
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: govuk-one-login/devplatform-upload-action-ecr@f82c8774a6390f200b15112b3cbb9faf3442173c
+        with:
+          role-to-assume-arn: ${{ secrets.AWS_DL_DEV_ROLE_ARN }}
+          build-and-push-image-only: true
+          artifact-bucket-name: ''
+          ecr-repo-name: ${{ secrets.DEV_ECR_REPOSITORY_TEST }}
+          dockerfile: test/Dockerfile
+          push-latest-tag: true
+          container-sign-kms-key-arn: ${{ secrets.DEV_CONTAINER_SIGN_KMS_KEY }}
+
+  app-image-build-and-push:
+    name: Build and push app image
+    runs-on: ubuntu-latest
+    needs: test-image-build-and-push
     env:
       AWS_REGION: eu-west-2
     permissions:


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed
Added test image build and push steps to the deploy to dev and deploy to build workflows.

<!-- Describe the changes in detail - the "what"-->

### Why did it change
When we add test steps into the pipelines we need test images in the ECR repos to run.
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-2128](https://govukverify.atlassian.net/browse/LIME-2128)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2128]: https://govukverify.atlassian.net/browse/LIME-2128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ