### PR TITLE
LIME-2036 Add FrontELB5xxPercentErrors Canary Alarm, disable DL5XXOnE…

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -724,10 +724,10 @@ Resources:
     Properties:
       TemplateURL: https://template-storage-templatebucket-1upzyw6v9cs42.s3.eu-west-2.amazonaws.com/ecs-canary-deployment/template.yaml?versionId=5RRU1nfKQD_d08FKttr8W7pzrAsqQiUM
       Parameters:
-        CloudWatchAlarms: !Sub
-          - "${MyAlarmOneVar},${MyAlarmTwoVar}"
-          - MyAlarmOneVar: !Ref DL5XXOnELB
-            MyAlarmTwoVar: !Ref FrontTargetGroup5xxPercentErrors
+        CloudWatchAlarms: !Join
+          - ","
+          - - !Ref FrontTargetGroup5xxPercentErrors
+            - !Ref FrontCanaryELB5xxPercentErrors
         CodeSigningConfigArn: !If
           - UseCodeSigning
           - !Ref CodeSigningConfigArn
@@ -1038,6 +1038,7 @@ Resources:
       ComparisonOperator: LessThanThreshold
       TreatMissingData: breaching
 
+  # TODO Remove once no longer referenced in deployed stack
   DL5XXOnELB:
     Type: AWS::CloudWatch::Alarm
     Properties:
@@ -1086,6 +1087,49 @@ Resources:
             Metric:
               Namespace: AWS/ApplicationELB
               MetricName: HTTPCode_Target_5XX_Count
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !GetAtt LoadBalancer.LoadBalancerFullName
+            Period: 60
+            Stat: Sum
+        - Id: m2
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApplicationELB
+              MetricName: RequestCount
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !GetAtt LoadBalancer.LoadBalancerFullName
+            Period: 60
+            Stat: Sum
+
+  # This alarm needs to be extremely sensitive, so it
+  # fires within the canary window as fast as possible.
+  FrontCanaryELB5xxPercentErrors:
+    Type: AWS::CloudWatch::Alarm
+    Condition: UseCanaryDeployment
+    Properties:
+      AlarmName: FrontCanaryELB5xxPercentErrors
+      AlarmDescription: >
+        The number of ELB HTTP 5XX server error codes that originate from the
+        load balancer is greater than 2% of all traffic.
+      EvaluationPeriods: 1
+      DatapointsToAlarm: 1
+      Threshold: 2
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: e1
+          Label: ErrorPercent
+          ReturnData: true
+          Expression: (m1/m2)*100
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApplicationELB
+              MetricName: HTTPCode_ELB_5XX_Count
               Dimensions:
                 - Name: LoadBalancer
                   Value: !GetAtt LoadBalancer.LoadBalancerFullName


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Add FrontELB5xxPercentErrors Canary Alarm

Disable DL5XXOnELB alarm

### Why did it change

To catch and rollback severe issues on new tasks, which are only visible on the ELB

DL5XXOnELB is incorrect and is looking at TargetGroup metrics not AWS/ApplicationELB metrics.
Disabled as the alarm needs to be removed from the AlarmList prior to removal from the template DL5XXOnELB (in follow up pr)

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-2036](https://govukverify.atlassian.net/browse/LIME-2036)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-2036]: https://govukverify.atlassian.net/browse/LIME-2036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ