### PR TITLE
LIME-2133 - Updated Accessibility Test Coverage

### DIFF
--- a/test/browser/features/wiremock_features/English/DLCommon/DLCommon.feature
+++ b/test/browser/features/wiremock_features/English/DLCommon/DLCommon.feature
@@ -110,6 +110,14 @@ Feature: Driving licence CRI - Common Tests
         Given I should be on the Landing Page with Page Title Was your UK photocard driving licence issued by DVLA or DVA?
         And I run the Axe Accessibility check against the DL Landing page
 
+    @mock-api:driving-licence-Accessibility @accessibility
+    Scenario: Driving Licence - Landing Page - There is a problem error displays when no radio button is selected
+        Given I click the continue button without selecting a radio button option
+        Then I see the Error Text There is a problem
+        And I see the Error Summary Text You must choose an option to continue
+        And I see the Hint Error Summary Text You must choose an option to continue
+        And I run the Axe Accessibility check against the DL Landing page
+
     @mock-api:driving-licence-ErrorPageSupportLinks
     Scenario: Driving Licence - Error Page - Contact GOV.UK One Login Link
         Given I should be on the Landing Page with Page Title Was your UK photocard driving licence issued by DVLA or DVA?

--- a/test/browser/features/wiremock_features/English/DVA/DVA.feature
+++ b/test/browser/features/wiremock_features/English/DVA/DVA.feature
@@ -380,6 +380,78 @@ Feature: DVA Driving licence CRI Error Validations
       | DeviceIntelligenceCookieName |
       | di-device-intelligence       |
 
+  @mock-api:dva-consoleErrorCheck @console-error-checks
+  Scenario: DVA - User navigates through the DVA Journey - Check for Console Errors
+    Given I see the back button on the DVA details page with text Back
+    And User clicks the back button
+    Then I should be on the Landing Page with Page Title Was your UK photocard driving licence issued by DVLA or DVA?
+    And User starts the Console Listener
+    And I click on DVA radio button and Continue
+    Then There are no console errors on the page
+
+  ########### Axe Accessibility ##########
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidDrivingLicenceNumber @accessibility
+  Scenario: DVA - Axe Accessibility Scan - DVA Details Page - Licence Number Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And DVA User re-enters drivingLicenceNumber as 5566778
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidPostcode @accessibility
+  Scenario: DVA - Axe Accessibility Scan - DVA Details Page - Postcode Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And User re-enters postcode as E20A
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidLastName @accessibility
+  Scenario: DVA - Axe Accessibility Scan - DVA Details Page - Name Field Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And User re-enters last name as KYLE123
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidDateOfBirth @accessibility
+  Scenario: DVA - Axe Accessibility Scan - DVA Details Page - Date of Birth Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And DVA user re-enters day of birth as 51
+    And DVA user re-enters month of birth as 71
+    And DVA user re-enters year of birth as 198
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidIssueDate @accessibility
+  Scenario: DVA - Axe Accessibility Scan - DVA Details Page - Issue Date Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And DVA user re-enters day of issue as AA
+    And DVA user re-enters month of issue as BB
+    And DVA user re-enters year of issue as AABC
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidExpiryDate @accessibility
+  Scenario: DVA - Axe Accessibility Scan - DVA Details Page - Valid To Date Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And User re-enters valid to day as AA
+    And User re-enters valid to month as BC
+    And User re-enters valid to year AABD
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-ConsentError @accessibility
+  Scenario: DVA - Axe Accessibility Scan - DVA Details Page - Consent Checkbox Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And DVA consent checkbox is unselected
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
   @QualityGateAccessibilityTest
   @mock-api:dva-accessibility @accessibility
   Scenario: DVA - Axe Accessibility Scan - DVA Details Page
@@ -392,12 +464,3 @@ Feature: DVA Driving licence CRI Error Validations
     And User clicks on continue
     Then they should see an error page
     Then I run the Axe Accessibility check against the DL Error page
-
-  @mock-api:dva-consoleErrorCheck @console-error-checks
-  Scenario: DVA - User navigates through the DVA Journey - Check for Console Errors
-    Given I see the back button on the DVA details page with text Back
-    And User clicks the back button
-    Then I should be on the Landing Page with Page Title Was your UK photocard driving licence issued by DVLA or DVA?
-    And User starts the Console Listener
-    And I click on DVA radio button and Continue
-    Then There are no console errors on the page

--- a/test/browser/features/wiremock_features/English/DVA/DVAAuthSource.feature
+++ b/test/browser/features/wiremock_features/English/DVA/DVAAuthSource.feature
@@ -43,19 +43,6 @@ Feature: DVA Driving licence - Auth Source
     And User clicks the back button
     Then I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
 
-  @QualityGateAccessibilityTest
-  @mock-api:dl-dva-auth-success @validation-regression @accessibility
-  Scenario: DVA Auth Source - Axe Accessibility Scan - Driving Licence - Check Your Details Page
-    Then I run the Axe Accessibility check against the Driving Licence check your details page
-
-  @QualityGateAccessibilityTest
-  @mock-api:dl-dva-auth-success @validation-regression @accessibility
-  Scenario: DVA Auth Source - Axe Accessibility Scan - Driving Licence - Consent Page
-    When I click on the Yes radio button
-    Then I click on the Confirm and Continue button
-    And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
-    And I run the Axe Accessibility check against the Driving Licence Consent page
-
   @mock-api:dl-dva-auth-success @console-error-checks
   Scenario: DVA Auth Source - User navigates through the Auth Source Journey - Check for Console Errors
     When I click on the Yes radio button
@@ -65,3 +52,33 @@ Feature: DVA Driving licence - Auth Source
     And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
     And I click on the DVA consent checkbox
     When I click on the Continue button
+
+  ########### Axe Accessibility ##########
+  @QualityGateAccessibilityTest
+  @mock-api:dl-dva-auth-success @validation-regression @accessibility
+  Scenario: DVA Auth Source - Axe Accessibility Scan - Driving Licence - Check Your Details Page - No Radio Selected Error
+    Then I click on the Confirm and Continue button
+    And I run the Axe Accessibility check against the Driving Licence check your details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-dva-auth-success @validation-regression @accessibility
+  Scenario: DVA Auth Source - Axe Accessibility Scan - Driving Licence - Check Your Details Page
+    Then I run the Axe Accessibility check against the Driving Licence check your details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-dva-auth-success @validation-regression @accessibility
+  Scenario: DVA Auth Source - Axe Accessibility Scan - Driving Licence - Consent Page - Missing Consent Error
+    When I click on the Yes radio button
+    Then I click on the Confirm and Continue button
+    And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
+    When I click on the Continue button
+    Then I see the No Consent Error Text You must give your consent to continue
+    And I run the Axe Accessibility check against the Driving Licence Consent page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-dva-auth-success @validation-regression @accessibility
+  Scenario: DVA Auth Source - Axe Accessibility Scan - Driving Licence - Consent Page
+    When I click on the Yes radio button
+    Then I click on the Confirm and Continue button
+    And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
+    And I run the Axe Accessibility check against the Driving Licence Consent page

--- a/test/browser/features/wiremock_features/English/DVLA/DVLA.feature
+++ b/test/browser/features/wiremock_features/English/DVLA/DVLA.feature
@@ -562,11 +562,6 @@ Feature: DVLA Driving licence CRI Error Validations
       | DeviceIntelligenceCookieName |
       | di-device-intelligence       |
 
-  @QualityGateAccessibilityTest
-  @mock-api:dvla-accessibility @accessibility
-  Scenario: DVLA - Axe Accessibility Scan - DVLA Details Page
-    Given I run the Axe Accessibility check against the DVLA Details page
-
   @mock-api:dva-consoleErrorCheck @console-error-checks
   Scenario: DVA - User navigates through the DVA Journey - Check for Console Errors
     Given I see the back button on the DVLA details page with text Back
@@ -575,3 +570,79 @@ Feature: DVLA Driving licence CRI Error Validations
     And User starts the Console Listener
     And I click on DVLA radio button and Continue
     Then There are no console errors on the page
+
+  ########### Axe Accessibility ##########
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Axe Accessibility Scan - DVLA Details Page - Licence Number Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters drivingLicenceNumber as PARKE610112PBF
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Axe Accessibility Scan - DVLA Details Page - Issue Number Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters issue number as 1
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Axe Accessibility Scan - DVLA Details Page - Postcode Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters postcode as E20A
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Axe Accessibility Scan - DVLA Details Page - Name Field Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters last name as KYLE123
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Axe Accessibility Scan - DVLA Details Page - Date of Birth Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters day of birth as 51
+    And User re-enters month of birth as 71
+    And User re-enters year of birth as 198
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Axe Accessibility Scan - DVLA Details Page - Issue Date Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters day of issue as AA
+    And User re-enters month of issue as BB
+    And User re-enters year of issue as AABC
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Axe Accessibility Scan - DVLA Details Page - Valid To Date Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters valid to day as AA
+    And User re-enters valid to month as BC
+    And User re-enters valid to year AABD
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Axe Accessibility Scan - DVLA Details Page - Consent Checkbox Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And DVLA consent checkbox is unselected
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dvla-accessibility @accessibility
+  Scenario: DVLA - Axe Accessibility Scan - DVLA Details Page
+    Given I run the Axe Accessibility check against the DVLA Details page

--- a/test/browser/features/wiremock_features/English/DVLA/DVLAAuthSource.feature
+++ b/test/browser/features/wiremock_features/English/DVLA/DVLAAuthSource.feature
@@ -43,19 +43,6 @@ Feature: DVLA Driving licence - Auth Source
         And User clicks the back button
         Then I should be on the Driving Licence check your details page Check your UK photocard driving licence details – GOV.UK One Login
 
-    @QualityGateAccessibilityTest
-    @mock-api:dl-dvla-auth-success @validation-regression @accessibility
-    Scenario: DVLA Auth Source - Axe Accessibility Scan - Driving Licence Check Your Details Page
-        Then I run the Axe Accessibility check against the Driving Licence check your details page
-
-    @QualityGateAccessibilityTest
-    @mock-api:dl-dvla-auth-success @validation-regression @accessibility
-    Scenario: DVLA Auth Source - Axe Accessibility Scan - Driving Licence - Consent Page
-        When I click on the Yes radio button
-        Then I click on the Confirm and Continue button
-        And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
-        And I run the Axe Accessibility check against the Driving Licence Consent page
-
     @mock-api:dl-dvla-auth-success @console-error-checks
     Scenario: DVLA Auth Source - User navigates through the Auth Source Journey - Check for Console Errors
         When I click on the Yes radio button
@@ -65,3 +52,33 @@ Feature: DVLA Driving licence - Auth Source
         And I should be on the DVLA consent page We need to check your driving licence details – GOV.UK One Login
         And I click on the DVLA consent checkbox
         When I click on the Continue button
+
+  ########### Axe Accessibility ##########
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dvla-auth-success @validation-regression @accessibility
+    Scenario: DVLA Auth Source - Axe Accessibility Scan - Driving Licence Check Your Details Page - No Radio Selected Error
+        Then I click on the Confirm and Continue button
+        And I run the Axe Accessibility check against the Driving Licence check your details page
+
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dvla-auth-success @validation-regression @accessibility
+    Scenario: DVLA Auth Source - Axe Accessibility Scan - Driving Licence Check Your Details Page
+        Then I run the Axe Accessibility check against the Driving Licence check your details page
+
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dvla-auth-success @validation-regression @accessibility
+    Scenario: DVLA Auth Source - Axe Accessibility Scan - Driving Licence - Consent Page - Missing Consent Error
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVLA consent page We need to check your driving licence details – GOV.UK One Login
+        When I click on the Continue button
+        Then I see the No Consent Error Text You must give your consent to continue
+        And I run the Axe Accessibility check against the Driving Licence Consent page
+
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dvla-auth-success @validation-regression @accessibility
+    Scenario: DVLA Auth Source - Axe Accessibility Scan - Driving Licence - Consent Page
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVA consent page We need to check your driving licence details – GOV.UK One Login
+        And I run the Axe Accessibility check against the Driving Licence Consent page

--- a/test/browser/features/wiremock_features/Welsh/DLCommon/WelshDLCommon.feature
+++ b/test/browser/features/wiremock_features/Welsh/DLCommon/WelshDLCommon.feature
@@ -72,3 +72,17 @@ Feature: Driving licence CRI - Common Tests - Welsh Translation
         Then I see the error page heading Mae'n ddrwg gennym, mae problem
         And I see the Contact the One Login team link which reads Cysylltu â thîm GOV.UK One Login (agor mewn tab newydd)
         And I assert the link on the error page is correct and live
+
+    ########### Axe Accessibility ##########
+    @QualityGateAccessibilityTest
+    @mock-api:driving-licence-Accessibility @accessibility
+    Scenario: Driving Licence - Welsh - Axe Accessibility Scan - DL Landing Page
+        Given I should be on the Landing Page with Page Title A oedd eich trwydded yrru cerdyn-llun y DU wedi'i chyhoeddi gan DVLA neu DVA?
+        And I run the Axe Accessibility check against the DL Landing page
+
+    @QualityGateAccessibilityTest
+    @mock-api:driving-licence-InvalidRadioSelection @accessibility
+    Scenario: Driving Licence - Welsh - Axe Accessibility Scan - DL Landing Page - No Radio Selected Error
+        Given I click the continue button without selecting a radio button option
+        Then I see the Error Text Mae problem
+        And I run the Axe Accessibility check against the DL Landing page

--- a/test/browser/features/wiremock_features/Welsh/DVA/WelshDVA.feature
+++ b/test/browser/features/wiremock_features/Welsh/DVA/WelshDVA.feature
@@ -351,3 +351,71 @@ Feature: DVA Driving licence CRI Error Validations - Welsh Translation
     Given I see the back button on the DVA details page with text Yn ôl
     And User clicks the back button
     And I see the Landing Page Title Summary Text Mae hwn i'w weld yn adran 4c o'ch trwydded yrru. Bydd naill ai’n dweud DVLA (Asiantaeth Trwyddedu Gyrru a Cherbydau) neu DVA (Asiantaeth Gyrwyr a Cherbydau).
+
+  ########### Axe Accessibility ##########
+  @QualityGateAccessibilityTest
+  @mock-api:dva-accessibility @accessibility
+  Scenario: DVA - Welsh - Axe Accessibility Scan - DVA Details Page
+    Given I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidDrivingLicenceNumber @accessibility
+  Scenario: DVA - Welsh - Axe Accessibility Scan - DVA Details Page - Licence Number Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And DVA User re-enters drivingLicenceNumber as 5566778
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidPostcode @accessibility
+  Scenario: DVA - Welsh - Axe Accessibility Scan - DVA Details Page - Postcode Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And User re-enters postcode as E20A
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidLastName @accessibility
+  Scenario: DVA - Welsh - Axe Accessibility Scan - DVA Details Page - Name Field Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And User re-enters last name as KYLE123
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidDateOfBirth @accessibility
+  Scenario: DVA - Welsh - Axe Accessibility Scan - DVA Details Page - Date of Birth Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And DVA user re-enters day of birth as 51
+    And DVA user re-enters month of birth as 71
+    And DVA user re-enters year of birth as 198
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidIssueDate @accessibility
+  Scenario: DVA - Welsh - Axe Accessibility Scan - DVA Details Page - Issue Date Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And DVA user re-enters day of issue as AA
+    And DVA user re-enters month of issue as BB
+    And DVA user re-enters year of issue as AABC
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-invalidExpiryDate @accessibility
+  Scenario: DVA - Welsh - Axe Accessibility Scan - DVA Details Page - Valid To Date Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And User re-enters valid to day as AA
+    And User re-enters valid to month as BC
+    And User re-enters valid to year AABD
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dva-ConsentError @accessibility
+  Scenario: DVA - Welsh - Axe Accessibility Scan - DVA Details Page - Consent Checkbox Error
+    Given User enters DVA data as a DrivingLicenceSubjectHappyBilly
+    And DVA consent checkbox is unselected
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVA Details page

--- a/test/browser/features/wiremock_features/Welsh/DVA/WelshDVAAuthSource.feature
+++ b/test/browser/features/wiremock_features/Welsh/DVA/WelshDVAAuthSource.feature
@@ -66,3 +66,33 @@ Feature: DVA Driving licence - Auth Source - Welsh Translation
         Then I see the back button on the DVA check your details page with text Yn ôl
         And User clicks the back button
         Then I should be on the Driving Licence check your details page Gwirio manylion eich trwydded yrru cerdyn-llun yn y DU – GOV.UK One Login
+
+    ########### Axe Accessibility ##########
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dva-auth-success @accessibility
+    Scenario: DVA Auth Source - Welsh - Axe Accessibility Scan - Check Your Details Page - No Radio Selected Error
+        Then I click on the Confirm and Continue button
+        And I run the Axe Accessibility check against the Driving Licence check your details page
+
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dva-auth-success @accessibility
+    Scenario: DVA Auth Source - Welsh - Axe Accessibility Scan - Check Your Details Page
+        Then I run the Axe Accessibility check against the Driving Licence check your details page
+
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dva-auth-success @accessibility
+    Scenario: DVA Auth Source - Welsh - Axe Accessibility Scan - Consent Page - Missing Consent Error
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
+        When I click on the Continue button
+        Then I see the No Consent Error Text Mae'n rhaid i chi roi eich caniatâd i barhau
+        And I run the Axe Accessibility check against the Driving Licence Consent page
+
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dva-auth-success @accessibility
+    Scenario: DVA Auth Source - Welsh - Axe Accessibility Scan - Consent Page
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
+        And I run the Axe Accessibility check against the Driving Licence Consent page

--- a/test/browser/features/wiremock_features/Welsh/DVLA/WelshDVLA.feature
+++ b/test/browser/features/wiremock_features/Welsh/DVLA/WelshDVLA.feature
@@ -419,3 +419,79 @@ Feature: DVLA Driving licence CRI Error Validations - Welsh Translation
     Given I see the back button on the DVLA details page with text Yn ôl
     And User clicks the back button
     Then I see the Landing Page Title Summary Text Mae hwn i'w weld yn adran 4c o'ch trwydded yrru. Bydd naill ai’n dweud DVLA (Asiantaeth Trwyddedu Gyrru a Cherbydau) neu DVA (Asiantaeth Gyrwyr a Cherbydau).
+
+  ########### Axe Accessibility ##########
+  @QualityGateAccessibilityTest
+  @mock-api:dvla-accessibility @accessibility
+  Scenario: DVLA - Welsh - Axe Accessibility Scan - DVLA Details Page
+    Given I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Welsh - Axe Accessibility Scan - DVLA Details Page - Licence Number Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters drivingLicenceNumber as PARKE610112PBF
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Welsh - Axe Accessibility Scan - DVLA Details Page - Issue Number Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters issue number as 1
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Welsh - Axe Accessibility Scan - DVLA Details Page - Postcode Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters postcode as E20A
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Welsh - Axe Accessibility Scan - DVLA Details Page - Name Field Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters last name as KYLE123
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Welsh - Axe Accessibility Scan - DVLA Details Page - Date of Birth Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters day of birth as 51
+    And User re-enters month of birth as 71
+    And User re-enters year of birth as 198
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Welsh - Axe Accessibility Scan - DVLA Details Page - Issue Date Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters day of issue as AA
+    And User re-enters month of issue as BB
+    And User re-enters year of issue as AABC
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Welsh - Axe Accessibility Scan - DVLA Details Page - Valid To Date Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And User re-enters valid to day as AA
+    And User re-enters valid to month as BC
+    And User re-enters valid to year AABD
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page
+
+  @QualityGateAccessibilityTest
+  @mock-api:dl-success @accessibility
+  Scenario: DVLA - Welsh - Axe Accessibility Scan - DVLA Details Page - Consent Checkbox Error
+    Given User enters DVLA data as a DrivingLicenceSubjectHappyPeter
+    And DVLA consent checkbox is unselected
+    When User clicks on continue
+    Then I run the Axe Accessibility check against the DVLA Details page

--- a/test/browser/features/wiremock_features/Welsh/DVLA/WelshDVLAAuthSource.feature
+++ b/test/browser/features/wiremock_features/Welsh/DVLA/WelshDVLAAuthSource.feature
@@ -67,3 +67,33 @@ Feature: DVLA Driving licence - Auth Source - Welsh Translation
         Then I see the back button on the DVLA check your details page with text Yn ôl
         And User clicks the back button
         Then I should be on the Driving Licence check your details page Gwirio manylion eich trwydded yrru cerdyn-llun yn y DU – GOV.UK One Login
+
+    ########### Axe Accessibility ##########
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dvla-auth-success @accessibility
+    Scenario: DVLA Auth Source - Welsh - Axe Accessibility Scan - Check Your Details Page - No Radio Selected Error
+        Then I click on the Confirm and Continue button
+        And I run the Axe Accessibility check against the Driving Licence check your details page
+
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dvla-auth-success @accessibility
+    Scenario: DVLA Auth Source - Welsh - Axe Accessibility Scan - Check Your Details Page
+        Then I run the Axe Accessibility check against the Driving Licence check your details page
+
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dvla-auth-success @accessibility
+    Scenario: DVLA Auth Source - Welsh - Axe Accessibility Scan - Consent Page - Missing Consent Error
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVLA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
+        When I click on the Continue button
+        Then I see the No Consent Error Text Mae'n rhaid i chi roi eich caniatâd i barhau
+        And I run the Axe Accessibility check against the Driving Licence Consent page
+
+    @QualityGateAccessibilityTest
+    @mock-api:dl-dvla-auth-success @accessibility
+    Scenario: DVLA Auth Source - Welsh - Axe Accessibility Scan - Consent Page
+        When I click on the Yes radio button
+        Then I click on the Confirm and Continue button
+        And I should be on the DVLA consent page Rydym angen gwirio manylion eich trwydded yrru – GOV.UK One Login
+        And I run the Axe Accessibility check against the Driving Licence Consent page

--- a/test/browser/step_definitions/wiremock_steps/CheckYourDetailsStepDefs.js
+++ b/test/browser/step_definitions/wiremock_steps/CheckYourDetailsStepDefs.js
@@ -19,7 +19,7 @@ Then(
   /^I run the Axe Accessibility check against the Driving Licence check your details page$/,
   async function () {
     const results = await new AxeBuilder({ page: this.page })
-      .withTags(["wcag22aa"])
+      .withTags(["wcag22aa", "best-practice"])
       .analyze();
 
     expect(results.violations).to.be.empty;

--- a/test/browser/step_definitions/wiremock_steps/licence-issuer.js
+++ b/test/browser/step_definitions/wiremock_steps/licence-issuer.js
@@ -316,7 +316,7 @@ Then(
   /^I run the Axe Accessibility check against the DL Landing page$/,
   async function () {
     const results = await new AxeBuilder({ page: this.page })
-      .withTags(["wcag22aa"])
+      .withTags(["wcag22aa", "best-practice"])
       .analyze();
 
     expect(results.violations).to.be.empty;


### PR DESCRIPTION
Updated coverage on:

DL Common Landing Page English and Welsh
DVA and DVA Auth Source English and Welsh
DVLA and DVLA Auth Source English and Welsh

Including Error Validation for all pages, i.e. invalid data entry, missing radio button and checkboxes etc

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Axe-core accessibility tests added for:

DL Common Landing Page English and Welsh
DVA and DVA Auth Source English and Welsh
DVLA and DVLA Auth Source English and Welsh

### Why did it change

To ensure full coverage of all pages is captured within the Accessibility Tests

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-2133](https://govukverify.atlassian.net/browse/LIME-2133)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->
<img width="391" height="93" alt="image" src="https://github.com/user-attachments/assets/7ad80aa9-11be-4e28-b248-ccf4b86f6624" />


[LIME-2133]: https://govukverify.atlassian.net/browse/LIME-2133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ